### PR TITLE
Derive PartialEq for Fingerprint

### DIFF
--- a/src/ssh/pubkey.rs
+++ b/src/ssh/pubkey.rs
@@ -113,7 +113,7 @@ impl fmt::Display for FingerprintKind {
 }
 
 /// A type that represents an OpenSSH public key fingerprint.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Fingerprint {
     /// The kind used to represent the fingerprint.
     pub kind: FingerprintKind,


### PR DESCRIPTION
I want to make it easier to just compare fingerprints.  I can add a test but not sure that's necessary since it's just going to compare the FingerprintKind and the String hash, which already have PartialEq derived.