### PR TITLE
Fix RSA Certificate Serialization Bug

### DIFF
--- a/src/ssh/cert.rs
+++ b/src/ssh/cert.rs
@@ -461,6 +461,7 @@ impl Certificate {
 
         writer.write_bytes(&signature);
 
+        self.signature = signature;
         self.serialized = writer.into_bytes();
         Ok(self)
     }

--- a/src/ssh/writer.rs
+++ b/src/ssh/writer.rs
@@ -173,8 +173,8 @@ impl Writer {
                 self.write_bytes(&key.key);
             },
             PublicKeyKind::Rsa(key) => {
-                self.write_bytes(&key.n);
-                self.write_bytes(&key.e);
+                self.write_mpint(&key.e);
+                self.write_mpint(&key.n);
             },
             PublicKeyKind::Ed25519(key) => {
                 self.write_bytes(&key.key);


### PR DESCRIPTION
This fixes compatibility issues when writing certificates to disk
for use by other software, such as ssh and sshd:

1. The keytype for the public key in a certificate is a "certificate key" type
2. The public key parts for RSA keys are swapped

These changes mean that ssh-keygen and sshcerts produce almost the same
signature. The only difference is the way ssh-keygen automatically adds
comments in some parts, and the order of critical options and extensions.