### PR TITLE
Use certificate key name for public key in certificates

### DIFF
--- a/src/ssh/cert.rs
+++ b/src/ssh/cert.rs
@@ -319,10 +319,12 @@ impl Certificate {
             Err(_) => return Err(Error::UnexpectedEof),
         };
         let serial = u64::from_be_bytes(serial);
+        let mut key = pubkey.clone();
+        key.key_type = key_type.clone();
 
         Ok(Certificate {
             nonce: nonce.to_vec(),
-            key: pubkey.clone(),
+            key,
             key_type,
             serial,
             cert_type,
@@ -409,9 +411,8 @@ impl Certificate {
     /// Take the certificate settings and generate a valid signature using the provided signer function
     pub fn sign(mut self, signer: impl FnOnce(&[u8]) -> Option<Vec<u8>>) -> Result<Self> {
         let mut writer = super::Writer::new();
-        let kt_name = format!("{}-cert-v01@openssh.com", self.key.key_type.name);
         // Write the cert type
-        writer.write_string(kt_name.as_str());
+        writer.write_string(self.key.key_type.name);
 
         // Write the nonce
         writer.write_bytes(&self.nonce);


### PR DESCRIPTION
OpenSSH changes the basic key type to the certificate equivalent [[1]]. The
exact reason remains unclear, as it is never checked when reading a
certificate. However, it is possible this will be added in a future version.

To stay compatible with openssh as much as possible, we also change the signed
key type to the cert variant.

[1]: https://github.com/openssh/openssh-portable/blob/2dc328023f60212cd29504fc05d849133ae47355/ssh-keygen.c#L1828