### PR TITLE
Add AllowedSigners support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ yubikey-lite = ["x509-support"]
 
 [dependencies]
 base64 = "0.13"
+chrono = "0.4"
 ring = "0.17"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     KeyTypeMismatch,
     /// The certificate is not signed correctly and invalid
     InvalidSignature,
+    /// Allowed Signer entry is invalid
+    InvalidAllowedSigner(String),
     /// A cryptographic operation failed.
     SigningError,
     /// An encrypted private key was provided with no decryption key
@@ -58,6 +60,7 @@ impl fmt::Display for Error {
             Error::NotCertificate => write!(f, "Not a certificate"),
             Error::KeyTypeMismatch => write!(f, "Key type mismatch"),
             Error::InvalidSignature => write!(f, "Data is improperly signed"),
+            Error::InvalidAllowedSigner(ref v) => write!(f, "Invalid allowed signer format: {}", v),
             Error::SigningError => write!(f, "Could not sign data"),
             Error::EncryptedPrivateKey => write!(f, "Encountered encrypted private key with no decryption key"),
             Error::EncryptedPrivateKeyNotSupported => write!(f, "This method of private key encryption is not supported or sshcerts was not compiled with encrypted private key support"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use std::{fmt, io, string};
+use crate::ssh::AllowedSignerParsingError;
 
 /// A type to represent the different kinds of errors.
 #[derive(Debug)]
@@ -22,8 +23,10 @@ pub enum Error {
     KeyTypeMismatch,
     /// The certificate is not signed correctly and invalid
     InvalidSignature,
-    /// Allowed Signer entry is invalid
-    InvalidAllowedSigner(String),
+    /// A parsing error for one allowed signer
+    InvalidAllowedSigner(AllowedSignerParsingError),
+    /// A parsing error for a collection/file of allowed signers
+    InvalidAllowedSigners(AllowedSignerParsingError, usize),
     /// A cryptographic operation failed.
     SigningError,
     /// An encrypted private key was provided with no decryption key
@@ -61,6 +64,7 @@ impl fmt::Display for Error {
             Error::KeyTypeMismatch => write!(f, "Key type mismatch"),
             Error::InvalidSignature => write!(f, "Data is improperly signed"),
             Error::InvalidAllowedSigner(ref v) => write!(f, "Invalid allowed signer format: {}", v),
+            Error::InvalidAllowedSigners(ref v, line) => write!(f, "Invalid allowed signer format on line {}: {}", line, v),
             Error::SigningError => write!(f, "Could not sign data"),
             Error::EncryptedPrivateKey => write!(f, "Encountered encrypted private key with no decryption key"),
             Error::EncryptedPrivateKeyNotSupported => write!(f, "This method of private key encryption is not supported or sshcerts was not compiled with encrypted private key support"),

--- a/src/ssh/allowed_signer.rs
+++ b/src/ssh/allowed_signer.rs
@@ -111,12 +111,9 @@ impl AllowedSigner {
         let mut valid_after = None;
         let mut valid_before = None;
 
-        println!("principals: {:?}", principals);
-
         let kt = loop {
             let option = tokenizer.next(false)?
                 .ok_or(Error::InvalidAllowedSigner(AllowedSignerParsingError::MissingKey))?;
-            println!("option: {}", option);
 
             let (option_key, option_value) = match option.split_once('=') {
                 Some(v) => v,
@@ -299,21 +296,27 @@ struct AllowedSignerSplitter {
 }
 
 impl AllowedSignerSplitter {
-    /// Split the string by delimiter but keep the delimiter as a separate token.
+    /// Split the string by delimiters but keep the delimiters.
     pub(in self) fn new(s: &str) -> Self {
         let mut buffer = Vec::new();
         let mut last = 0;
+
         for (index, matched) in s.match_indices([' ', '"', '#']) {
+            // Push the new text before the delimiter
             if last != index {
                 buffer.push(s[last..index].to_owned());
             }
+            // Push the delimiter
             buffer.push(matched.to_owned());
             last = index + matched.len();
         }
+
+        // Push the remaining text
         if last < s.len() {
             buffer.push(s[last..].to_owned());
         }
 
+        // We parse from left to right so reversing allow us to use Vec's last() and pop()
         buffer.reverse();
 
         Self { buffer }

--- a/src/ssh/allowed_signer.rs
+++ b/src/ssh/allowed_signer.rs
@@ -293,6 +293,11 @@ impl AllowedSigners {
 }
 
 /// A type used to split the allowed signer segments, abstracting out the handling of double quotes.
+/// The splitter is highly aware of the allowed_signer format and will catch certain invalid
+/// formats.
+///
+/// For example: "principals   option1=\"value1   value2\" option2 option3=value kt key_data" is split into
+/// ["principals", "option1=\"value1   value2\"", "option2", "option3=value", "kt", "key_data"]
 struct AllowedSignerSplitter {
     /// A buffer of remaining tokens in reverse order.
     buffer: Vec<String>,

--- a/src/ssh/allowed_signer.rs
+++ b/src/ssh/allowed_signer.rs
@@ -1,0 +1,218 @@
+use std::collections::VecDeque;
+use std::fmt;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use super::pubkey::PublicKey;
+use crate::{error::Error, Result};
+
+/// A type which represents an allowed signer entry.
+/// Please refer to [ssh-keygen-1.ALLOWED_SIGNERS] for more details about the format.
+/// [ssh-keygen-1.ALLOWED_SIGNERS]: https://man.openbsd.org/ssh-keygen.1#ALLOWED_SIGNERS
+#[derive(Debug, PartialEq, Eq)]
+pub struct AllowedSigner {
+    /// A list of principals, each in the format USER@DOMAIN.
+    pub principals: Vec<String>,
+
+    /// Indicates that this key is accepted as a CA.
+    /// This is a standard option.
+    pub cert_authority: bool,
+
+    /// Specifies a list of namespaces that are accepted for this key.
+    /// This is a standard option.
+    ///
+    /// Note: The specification allows spaces inside double quotes. However, this is not supported.
+    pub namespaces: Option<Vec<String>>,
+
+    /// Time at or after which the key is valid.
+    /// This is a standard option.
+    pub valid_after: Option<u64>,
+
+    /// Time at or before which the key is valid.
+    /// This is a standard option.
+    pub valid_before: Option<u64>,
+
+    /// Public key of the entry.
+    pub key: PublicKey,
+}
+
+/// A type which represents a collection of allowed signer entries.
+/// Please refer to [ssh-keygen-1.ALLOWED_SIGNERS] for more details about the format.
+/// [ssh-keygen-1.ALLOWED_SIGNERS]: https://man.openbsd.org/ssh-keygen.1#ALLOWED_SIGNERS
+#[derive(Debug, PartialEq, Eq)]
+pub struct AllowedSigners {
+    /// A collection of allowed signers
+    pub allowed_signers: Vec<AllowedSigner>,
+}
+
+impl AllowedSigner {
+    /// Parse an allowed signer entry from a given string.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use sshcerts::ssh::AllowedSigner;
+    ///
+    /// let allowed_signer = AllowedSigner::from_string(concat!(
+    ///     "user@domain.tld ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBGJe",
+    ///     "+IDGRhlQdDp+/AIsTXGaVhWaQUbHJwqLDlQIh7V4xatO6E/4Uva+f70WzxgM7xHPGUqafqNAcxxVBP4jkx3HVDRSr7C3",
+    ///     "NVBpr0ZaKXu/hFiCo/4kry4H5MGMEvKATA=="
+    /// )).unwrap();
+    /// println!("{:?}", allowed_signer);
+    /// ```
+    pub fn from_string(s: &str) -> Result<AllowedSigner> {
+        let mut parts: VecDeque<&str> = s.split_whitespace().collect();
+
+        // An allowed signer must contian at least 3 parts: principals, key type and pubkey data
+        if parts.len() < 3 {
+            return Err(Error::InvalidFormat);
+        }
+
+        let principals = parts.pop_front().ok_or(Error::InvalidFormat)?;
+        let principals: Vec<&str> = principals.split(',').collect();
+        let principals = principals.iter().map(|s| s.to_string()).collect();
+
+        let key_data = parts.pop_back().ok_or(Error::InvalidFormat)?;
+        let kt = parts.pop_back().ok_or(Error::InvalidFormat)?;
+        let key = PublicKey::from_string(format!("{} {}", kt, key_data).as_str())?;
+
+        let mut cert_authority = false;
+        let mut namespaces = None;
+        let mut valid_after = None;
+        let mut valid_before = None;
+
+        for option in parts {
+            let option = option.to_lowercase();
+            let (key, value) = match option.split_once('=') {
+                Some(v) => v,
+                None => (option.as_str(), ""),
+            };
+            match key {
+                "cert-authority" => cert_authority = true,
+                "namespaces" => {
+                    if namespaces.is_some() {
+                        return Err(Error::InvalidFormat);
+                    }
+                    let namespaces_inner: Vec<&str> = value.trim_matches('"')
+                            .split(',')
+                            .collect();
+                    namespaces = Some(
+                        namespaces_inner.iter()
+                            .map(|s| s.to_string())
+                            .collect()
+                    );
+                },
+                "valid-after" => {
+                    if valid_after.is_some() {
+                        return Err(Error::InvalidFormat);
+                    }
+                    valid_after = Some(parse_timestamp(value)?);
+                },
+                "valid-before" => {
+                    if valid_before.is_some() {
+                        return Err(Error::InvalidFormat);
+                    }
+                    valid_before = Some(parse_timestamp(value)?);
+                },
+                _ => return Err(Error::InvalidFormat),
+            };
+        }
+
+        Ok(AllowedSigner{
+            principals,
+            cert_authority,
+            namespaces,
+            valid_after,
+            valid_before,
+            key,
+        })
+    }
+}
+
+impl fmt::Display for AllowedSigner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut output = String::new();
+
+        output.push_str(&self.principals.join(","));
+        
+        if self.cert_authority {
+            output.push_str(" cert-authority");
+        }
+
+        if let Some(ref namespaces) = self.namespaces {
+            output.push_str(&format!(" namespaces={}", namespaces.join(",")));
+        }
+
+        if let Some(valid_after) = self.valid_after {
+            output.push_str(&format!(" valid-after={}", valid_after));
+        }
+
+        if let Some(valid_before) = self.valid_before {
+            output.push_str(&format!(" valid-before={}", valid_before));
+        }
+
+        output.push_str(&format!(" {}", self.key));
+
+        write!(f, "{}", output)
+    }
+}
+
+impl AllowedSigners {
+    /// Reads AllowedSigners from a given path.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use sshcerts::ssh::AllowedSigners;
+    /// fn example() {
+    ///     let allowed_signers = AllowedSigners::from_path("/path/to/allowed_signers").unwrap();
+    ///     println!("{:?}", allowed_signers);
+    /// }
+    /// ```
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<AllowedSigners> {
+        let mut contents = String::new();
+        File::open(path)?.read_to_string(&mut contents)?;
+
+        AllowedSigners::from_string(&contents)
+    }
+
+    /// Parse a collection of allowed signers from a given string.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use sshcerts::ssh::AllowedSigners;
+    ///
+    /// let allowed_signers = AllowedSigners::from_string(concat!(
+    ///     "user@domain.tld ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBGJe",
+    ///     "+IDGRhlQdDp+/AIsTXGaVhWaQUbHJwqLDlQIh7V4xatO6E/4Uva+f70WzxgM7xHPGUqafqNAcxxVBP4jkx3HVDRSr7C3",
+    ///     "NVBpr0ZaKXu/hFiCo/4kry4H5MGMEvKATA==\n",
+    ///     "user@domain.tld ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBGJe",
+    ///     "+IDGRhlQdDp+/AIsTXGaVhWaQUbHJwqLDlQIh7V4xatO6E/4Uva+f70WzxgM7xHPGUqafqNAcxxVBP4jkx3HVDRSr7C3",
+    ///     "NVBpr0ZaKXu/hFiCo/4kry4H5MGMEvKATA==\n"
+    /// )).unwrap();
+    /// println!("{:?}", allowed_signers);
+    /// ```
+    pub fn from_string(s: &str) -> Result<AllowedSigners> {
+        let mut allowed_signers = Vec::new();
+
+        for line in s.split('\n') {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with("#") {
+                continue;
+            }
+            let allowed_signer = AllowedSigner::from_string(line)?;
+            allowed_signers.push(allowed_signer);
+        }
+
+        Ok(AllowedSigners{allowed_signers})
+    }
+}
+
+/// Parse a string into a u64 representing a timestamp.
+/// The timestamp can be enclosed by quotation marks.
+fn parse_timestamp(s: &str) -> Result<u64> {
+    let s = s.trim_matches('"');
+    Ok(s.parse::<u64>().map_err(|_| Error::InvalidFormat)?)
+}

--- a/src/ssh/allowed_signer.rs
+++ b/src/ssh/allowed_signer.rs
@@ -305,7 +305,7 @@ struct AllowedSignerSplitter {
 
 impl AllowedSignerSplitter {
     /// Split the string by delimiters but keep the delimiters.
-    pub(in self) fn new(s: &str) -> Self {
+    pub(self) fn new(s: &str) -> Self {
         let mut buffer = Vec::new();
         let mut last = 0;
 
@@ -330,14 +330,14 @@ impl AllowedSignerSplitter {
         Self { buffer }
     }
 
-    pub(in self) fn is_empty_after_trim(&mut self) -> bool {
+    pub(self) fn is_empty_after_trim(&mut self) -> bool {
         self.trim();
         return self.buffer.is_empty();
     }
 
     /// Get the next part that is not an option (principals, key)
     /// If opening_quotes_allowed is set to false, we reject the next token if it starts with ".
-    pub(in self) fn next(&mut self, opening_quotes_allowed: bool) -> Result<Option<String>> {
+    pub(self) fn next(&mut self, opening_quotes_allowed: bool) -> Result<Option<String>> {
         if self.is_empty_after_trim() {
             return Ok(None);
         }

--- a/src/ssh/allowed_signer.rs
+++ b/src/ssh/allowed_signer.rs
@@ -22,7 +22,8 @@ pub struct AllowedSigner {
     /// Specifies a list of namespaces that are accepted for this key.
     /// This is a standard option.
     ///
-    /// Note: The specification allows spaces inside double quotes. However, this is not supported.
+    /// Note: The specification allows spaces inside double quotes. However, in this
+    /// implementation, spaces would cause the parser to reject the input.
     pub namespaces: Option<Vec<String>>,
 
     /// Time at or after which the key is valid.

--- a/src/ssh/allowed_signer.rs
+++ b/src/ssh/allowed_signer.rs
@@ -306,7 +306,7 @@ struct AllowedSignerSplitter {
 
 impl AllowedSignerSplitter {
     /// Split the string by delimiters but keep the delimiters.
-    pub(self) fn new(s: &str) -> Self {
+    fn new(s: &str) -> Self {
         let mut buffer = Vec::new();
         let mut last = 0;
 
@@ -331,14 +331,14 @@ impl AllowedSignerSplitter {
         Self { buffer }
     }
 
-    pub(self) fn is_empty_after_trim(&mut self) -> bool {
+    fn is_empty_after_trim(&mut self) -> bool {
         self.trim();
         return self.buffer.is_empty();
     }
 
     /// Get the next part that is not an option (principals, key)
     /// If opening_quotes_allowed is set to false, we reject the next token if it starts with ".
-    pub(self) fn next(&mut self, opening_quotes_allowed: bool) -> Result<Option<String>> {
+    fn next(&mut self, opening_quotes_allowed: bool) -> Result<Option<String>> {
         if self.is_empty_after_trim() {
             return Ok(None);
         }

--- a/src/ssh/allowed_signer.rs
+++ b/src/ssh/allowed_signer.rs
@@ -102,11 +102,12 @@ impl AllowedSigner {
         let principals = tokenizer.next(true)?
             .ok_or(Error::InvalidAllowedSigner(AllowedSignerParsingError::MissingPrincipals))?;
         let principals = principals.trim_matches('"');
-        let principals: Vec<&str> = principals.split(',').collect();
+        let principals: Vec<String> = principals.split(',')
+            .map(|s| s.to_string())
+            .collect();
         if principals.iter().any(|p| p.is_empty()) {
             return Err(Error::InvalidAllowedSigner(AllowedSignerParsingError::InvalidPrincipals));
         }
-        let principals = principals.iter().map(|s| s.to_string()).collect();
 
         let mut cert_authority = false;
         let mut namespaces = None;

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -24,7 +24,7 @@ pub trait SSHCertificateSigner {
     fn sign(&self, buffer: &[u8]) -> Option<Vec<u8>>;
 }
 
-pub use self::allowed_signer::{AllowedSigner, AllowedSigners};
+pub use self::allowed_signer::{AllowedSigner, AllowedSigners, AllowedSignerParsingError};
 pub use self::cert::{CertType, Certificate};
 pub use self::keytype::{Curve, CurveKind, KeyType, KeyTypeKind};
 pub use self::privkey::{

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -8,6 +8,7 @@ All rights reserved.
 //! support that. The original licence for the code is in the source
 //! code provided
 
+mod allowed_signer;
 mod cert;
 mod keytype;
 mod privkey;
@@ -23,6 +24,7 @@ pub trait SSHCertificateSigner {
     fn sign(&self, buffer: &[u8]) -> Option<Vec<u8>>;
 }
 
+pub use self::allowed_signer::{AllowedSigner, AllowedSigners};
 pub use self::cert::{CertType, Certificate};
 pub use self::keytype::{Curve, CurveKind, KeyType, KeyTypeKind};
 pub use self::privkey::{

--- a/tests/allowed-signer.rs
+++ b/tests/allowed-signer.rs
@@ -61,7 +61,7 @@ fn parse_good_allowed_signer_with_options() {
         Some(vec!["thanh".to_string(), "mitchell".to_string()])
     );
     assert!(allowed_signer.valid_after.is_none());
-    assert_eq!(allowed_signer.valid_before, Some(1714867200i64));
+    assert_eq!(allowed_signer.valid_before, Some(1714881600i64));
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn parse_good_allowed_signer_with_hm_timestamp() {
         allowed_signer.namespaces,
         Some(vec!["thanh".to_string(), "mitchell".to_string()])
     );
-    assert_eq!(allowed_signer.valid_after, Some(1714870920));
+    assert_eq!(allowed_signer.valid_after, Some(1714885320i64));
     assert!(allowed_signer.valid_before.is_none());
 }
 
@@ -123,7 +123,7 @@ fn parse_good_allowed_signer_with_hms_timestamp() {
         allowed_signer.namespaces,
         Some(vec!["thanh".to_string(), "mitchell".to_string()])
     );
-    assert_eq!(allowed_signer.valid_after, Some(1714870950));
+    assert_eq!(allowed_signer.valid_after, Some(1714885350i64));
     assert!(allowed_signer.valid_before.is_none());
 }
 
@@ -145,7 +145,7 @@ fn parse_good_allowed_signer_with_consecutive_spaces() {
         Some(vec!["thanh".to_string(), "#mitchell".to_string()])
     );
     assert!(allowed_signer.valid_after.is_none());
-    assert_eq!(allowed_signer.valid_before, Some(1714867200i64));
+    assert_eq!(allowed_signer.valid_before, Some(1714881600i64));
 }
 
 #[test]

--- a/tests/allowed-signer.rs
+++ b/tests/allowed-signer.rs
@@ -26,6 +26,7 @@ fn parse_good_allowed_signer_with_options() {
     let allowed_signer =
         "mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces=\"thanh,mitchell\" valid-before=\"123\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
     let allowed_signer = AllowedSigner::from_string(allowed_signer);
+    println!("{:?}", allowed_signer);
     assert!(allowed_signer.is_ok());
     let allowed_signer = allowed_signer.unwrap();
     assert_eq!(allowed_signer.key.fingerprint().to_string(), "SHA256:QAtqtvvCePelMMUNPP7madH2zNa1ATxX1nt9L/0C5+M");
@@ -58,6 +59,48 @@ fn parse_good_allowed_signer_with_consecutive_spaces() {
     assert_eq!(
         allowed_signer.namespaces, 
         Some(vec!["thanh".to_string(), "#mitchell".to_string()])
+    );
+    assert!(allowed_signer.valid_after.is_none());
+    assert_eq!(allowed_signer.valid_before, Some(123u64));
+}
+
+#[test]
+fn parse_good_allowed_signer_with_empty_namespaces() {
+    let allowed_signer =
+        "mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces=\"thanh,,mitchell\" valid-before=\"123\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+    let allowed_signer = AllowedSigner::from_string(allowed_signer);
+    assert!(allowed_signer.is_ok());
+    let allowed_signer = allowed_signer.unwrap();
+    assert_eq!(allowed_signer.key.fingerprint().to_string(), "SHA256:QAtqtvvCePelMMUNPP7madH2zNa1ATxX1nt9L/0C5+M");
+    assert_eq!(
+        allowed_signer.principals,
+        vec!["mitchell@confurious.io".to_string(), "mitchel2@confurious.io".to_string()],
+    );
+    assert!(allowed_signer.cert_authority);
+    assert_eq!(
+        allowed_signer.namespaces, 
+        Some(vec!["thanh".to_string(), "mitchell".to_string()])
+    );
+    assert!(allowed_signer.valid_after.is_none());
+    assert_eq!(allowed_signer.valid_before, Some(123u64));
+}
+
+#[test]
+fn parse_good_allowed_signer_with_space_in_namespaces() {
+    let allowed_signer =
+        "mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces=\"thanh,mitchell   tech\" valid-before=\"123\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+    let allowed_signer = AllowedSigner::from_string(allowed_signer);
+    assert!(allowed_signer.is_ok());
+    let allowed_signer = allowed_signer.unwrap();
+    assert_eq!(allowed_signer.key.fingerprint().to_string(), "SHA256:QAtqtvvCePelMMUNPP7madH2zNa1ATxX1nt9L/0C5+M");
+    assert_eq!(
+        allowed_signer.principals,
+        vec!["mitchell@confurious.io".to_string(), "mitchel2@confurious.io".to_string()],
+    );
+    assert!(allowed_signer.cert_authority);
+    assert_eq!(
+        allowed_signer.namespaces, 
+        Some(vec!["thanh".to_string(), "mitchell   tech".to_string()])
     );
     assert!(allowed_signer.valid_after.is_none());
     assert_eq!(allowed_signer.valid_before, Some(123u64));

--- a/tests/allowed-signer.rs
+++ b/tests/allowed-signer.rs
@@ -43,6 +43,27 @@ fn parse_good_allowed_signer_with_options() {
 }
 
 #[test]
+fn parse_good_allowed_signer_with_consecutive_spaces() {
+    let allowed_signer =
+        "mitchell@confurious.io,mitchel2@confurious.io    cert-authority    namespaces=\"thanh,#mitchell\" valid-before=\"123\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5  ";
+    let allowed_signer = AllowedSigner::from_string(allowed_signer);
+    assert!(allowed_signer.is_ok());
+    let allowed_signer = allowed_signer.unwrap();
+    assert_eq!(allowed_signer.key.fingerprint().to_string(), "SHA256:QAtqtvvCePelMMUNPP7madH2zNa1ATxX1nt9L/0C5+M");
+    assert_eq!(
+        allowed_signer.principals,
+        vec!["mitchell@confurious.io".to_string(), "mitchel2@confurious.io".to_string()],
+    );
+    assert!(allowed_signer.cert_authority);
+    assert_eq!(
+        allowed_signer.namespaces, 
+        Some(vec!["thanh".to_string(), "#mitchell".to_string()])
+    );
+    assert!(allowed_signer.valid_after.is_none());
+    assert_eq!(allowed_signer.valid_before, Some(123u64));
+}
+
+#[test]
 fn parse_bad_allowed_signer_with_wrong_key_type() {
     let allowed_signer =
         "mitchell@confurious.io ecdsa-sha2-nistp384 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
@@ -75,6 +96,14 @@ fn parse_bad_allowed_signer_with_invalid_namespaces() {
 fn parse_bad_allowed_signer_with_invalid_principals() {
     let allowed_signer =
         "mitchell@confurious.io ,thanh@timweri.me option=test ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+    let allowed_signer = AllowedSigner::from_string(allowed_signer);
+    assert!(allowed_signer.is_err());
+}
+
+#[test]
+fn parse_bad_allowed_signer_with_empty_principal() {
+    let allowed_signer =
+        "mitchell@confurious.io,,thanh@timweri.me option=test ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
     let allowed_signer = AllowedSigner::from_string(allowed_signer);
     assert!(allowed_signer.is_err());
 }

--- a/tests/allowed-signer.rs
+++ b/tests/allowed-signer.rs
@@ -5,7 +5,6 @@ fn parse_good_allowed_signer() {
     let allowed_signer =
         "mitchell@confurious.io ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
     let allowed_signer = AllowedSigner::from_string(allowed_signer);
-    println!("{:?}", allowed_signer);
     assert!(allowed_signer.is_ok());
     let allowed_signer = allowed_signer.unwrap();
     assert_eq!(
@@ -27,7 +26,6 @@ fn parse_good_allowed_signer_with_quoted_principals() {
     let allowed_signer =
         "\"mitchell@confurious.io,mitchell\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
     let allowed_signer = AllowedSigner::from_string(allowed_signer);
-    println!("{:?}", allowed_signer);
     assert!(allowed_signer.is_ok());
     let allowed_signer = allowed_signer.unwrap();
     assert_eq!(
@@ -49,7 +47,6 @@ fn parse_good_allowed_signer_with_options() {
     let allowed_signer =
         "mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces=\"thanh,mitchell\" valid-before=\"123\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
     let allowed_signer = AllowedSigner::from_string(allowed_signer);
-    println!("{:?}", allowed_signer);
     assert!(allowed_signer.is_ok());
     let allowed_signer = allowed_signer.unwrap();
     assert_eq!(allowed_signer.key.fingerprint().to_string(), "SHA256:QAtqtvvCePelMMUNPP7madH2zNa1ATxX1nt9L/0C5+M");

--- a/tests/allowed-signer.rs
+++ b/tests/allowed-signer.rs
@@ -46,7 +46,7 @@ fn parse_good_allowed_signer_with_quoted_principals() {
 #[test]
 fn parse_good_allowed_signer_with_options() {
     let allowed_signer =
-        "mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces=\"thanh,mitchell\" valid-before=\"20240505\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+        "mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces=\"thanh,mitchell\" valid-before=\"20240505Z\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
     let allowed_signer = AllowedSigner::from_string(allowed_signer);
     assert!(allowed_signer.is_ok());
     let allowed_signer = allowed_signer.unwrap();
@@ -61,7 +61,7 @@ fn parse_good_allowed_signer_with_options() {
         Some(vec!["thanh".to_string(), "mitchell".to_string()])
     );
     assert!(allowed_signer.valid_after.is_none());
-    assert_eq!(allowed_signer.valid_before, Some(1714881600i64));
+    assert_eq!(allowed_signer.valid_before, Some(1714867200i64));
 }
 
 #[test]
@@ -88,7 +88,7 @@ fn parse_good_allowed_signer_with_utc_timestamp() {
 #[test]
 fn parse_good_allowed_signer_with_hm_timestamp() {
     let allowed_signer =
-        "mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces=\"thanh,mitchell\" valid-after=202405050102 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+        "mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces=\"thanh,mitchell\" valid-after=202405050102Z ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
     let allowed_signer = AllowedSigner::from_string(allowed_signer);
     assert!(allowed_signer.is_ok());
     let allowed_signer = allowed_signer.unwrap();
@@ -102,14 +102,14 @@ fn parse_good_allowed_signer_with_hm_timestamp() {
         allowed_signer.namespaces,
         Some(vec!["thanh".to_string(), "mitchell".to_string()])
     );
-    assert_eq!(allowed_signer.valid_after, Some(1714885320i64));
+    assert_eq!(allowed_signer.valid_after, Some(1714870920i64));
     assert!(allowed_signer.valid_before.is_none());
 }
 
 #[test]
 fn parse_good_allowed_signer_with_hms_timestamp() {
     let allowed_signer =
-        "mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces=\"thanh,mitchell\" valid-after=20240505010230 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+        "mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces=\"thanh,mitchell\" valid-after=20240505010230Z ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
     let allowed_signer = AllowedSigner::from_string(allowed_signer);
     assert!(allowed_signer.is_ok());
     let allowed_signer = allowed_signer.unwrap();
@@ -123,14 +123,14 @@ fn parse_good_allowed_signer_with_hms_timestamp() {
         allowed_signer.namespaces,
         Some(vec!["thanh".to_string(), "mitchell".to_string()])
     );
-    assert_eq!(allowed_signer.valid_after, Some(1714885350i64));
+    assert_eq!(allowed_signer.valid_after, Some(1714870950i64));
     assert!(allowed_signer.valid_before.is_none());
 }
 
 #[test]
 fn parse_good_allowed_signer_with_consecutive_spaces() {
     let allowed_signer =
-        "mitchell@confurious.io,mitchel2@confurious.io    cert-authority    namespaces=\"thanh,#mitchell\" valid-before=\"20240505\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5  ";
+        "mitchell@confurious.io,mitchel2@confurious.io    cert-authority    namespaces=\"thanh,#mitchell\" valid-before=\"20240505Z\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5  ";
     let allowed_signer = AllowedSigner::from_string(allowed_signer);
     assert!(allowed_signer.is_ok());
     let allowed_signer = allowed_signer.unwrap();
@@ -145,7 +145,7 @@ fn parse_good_allowed_signer_with_consecutive_spaces() {
         Some(vec!["thanh".to_string(), "#mitchell".to_string()])
     );
     assert!(allowed_signer.valid_after.is_none());
-    assert_eq!(allowed_signer.valid_before, Some(1714881600i64));
+    assert_eq!(allowed_signer.valid_before, Some(1714867200i64));
 }
 
 #[test]

--- a/tests/allowed-signer.rs
+++ b/tests/allowed-signer.rs
@@ -59,6 +59,19 @@ fn parse_bad_allowed_signer_with_invalid_option() {
 }
 
 #[test]
+fn parse_bad_allowed_signer_with_invalid_namespaces() {
+    let allowed_signer =
+        "mitchell@confurious.io namespaces=a\"test\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+    let allowed_signer = AllowedSigner::from_string(allowed_signer);
+    assert!(allowed_signer.is_err());
+
+    let allowed_signer =
+        "mitchell@confurious.io namespaces=\"tester,thanh\"\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+    let allowed_signer = AllowedSigner::from_string(allowed_signer);
+    assert!(allowed_signer.is_err());
+}
+
+#[test]
 fn parse_bad_allowed_signer_with_invalid_principals() {
     let allowed_signer =
         "mitchell@confurious.io ,thanh@timweri.me option=test ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
@@ -70,6 +83,14 @@ fn parse_bad_allowed_signer_with_invalid_principals() {
 fn parse_bad_allowed_signer_with_timestamp_option() {
     let allowed_signer =
         "mitchell@confurious.io valid-before=-143 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+    let allowed_signer = AllowedSigner::from_string(allowed_signer);
+    assert!(allowed_signer.is_err());
+}
+
+#[test]
+fn parse_bad_allowed_signer_with_conflicting_timestamps() {
+    let allowed_signer =
+        "mitchell@confurious.io valid-before=143 valid-after=145 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
     let allowed_signer = AllowedSigner::from_string(allowed_signer);
     assert!(allowed_signer.is_err());
 }

--- a/tests/allowed-signer.rs
+++ b/tests/allowed-signer.rs
@@ -1,0 +1,83 @@
+use sshcerts::ssh::AllowedSigner;
+
+#[test]
+fn parse_good_allowed_signer() {
+    let allowed_signer =
+        "mitchell@confurious.io ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+    let allowed_signer = AllowedSigner::from_string(allowed_signer);
+    assert!(allowed_signer.is_ok());
+    let allowed_signer = allowed_signer.unwrap();
+    assert_eq!(
+        allowed_signer.key.fingerprint().to_string(),
+        "SHA256:QAtqtvvCePelMMUNPP7madH2zNa1ATxX1nt9L/0C5+M",
+    );
+    assert_eq!(
+        allowed_signer.principals,
+        vec!["mitchell@confurious.io".to_string()],
+    );
+    assert!(!allowed_signer.cert_authority);
+    assert!(allowed_signer.namespaces.is_none());
+    assert!(allowed_signer.valid_after.is_none());
+    assert!(allowed_signer.valid_before.is_none());
+}
+
+#[test]
+fn parse_good_allowed_signer_with_options() {
+    let allowed_signer =
+        "mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces=\"thanh,mitchell\" valid-before=\"123\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+    let allowed_signer = AllowedSigner::from_string(allowed_signer);
+    assert!(allowed_signer.is_ok());
+    let allowed_signer = allowed_signer.unwrap();
+    assert_eq!(allowed_signer.key.fingerprint().to_string(), "SHA256:QAtqtvvCePelMMUNPP7madH2zNa1ATxX1nt9L/0C5+M");
+    assert_eq!(
+        allowed_signer.principals,
+        vec!["mitchell@confurious.io".to_string(), "mitchel2@confurious.io".to_string()],
+    );
+    assert!(allowed_signer.cert_authority);
+    assert_eq!(
+        allowed_signer.namespaces, 
+        Some(vec!["thanh".to_string(), "mitchell".to_string()])
+    );
+    assert!(allowed_signer.valid_after.is_none());
+    assert_eq!(allowed_signer.valid_before, Some(123u64));
+}
+
+#[test]
+fn parse_bad_allowed_signer_with_wrong_key_type() {
+    let allowed_signer =
+        "mitchell@confurious.io ecdsa-sha2-nistp384 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+    let allowed_signer = AllowedSigner::from_string(allowed_signer);
+    assert!(allowed_signer.is_err());
+}
+
+#[test]
+fn parse_bad_allowed_signer_with_invalid_option() {
+    let allowed_signer =
+        "mitchell@confurious.io option=test ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+    let allowed_signer = AllowedSigner::from_string(allowed_signer);
+    assert!(allowed_signer.is_err());
+}
+
+#[test]
+fn parse_bad_allowed_signer_with_invalid_principals() {
+    let allowed_signer =
+        "mitchell@confurious.io ,thanh@timweri.me option=test ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+    let allowed_signer = AllowedSigner::from_string(allowed_signer);
+    assert!(allowed_signer.is_err());
+}
+
+#[test]
+fn parse_bad_allowed_signer_with_timestamp_option() {
+    let allowed_signer =
+        "mitchell@confurious.io valid-before=-143 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+    let allowed_signer = AllowedSigner::from_string(allowed_signer);
+    assert!(allowed_signer.is_err());
+}
+
+#[test]
+fn parse_bad_allowed_signer_with_duplicate_option() {
+    let allowed_signer =
+        "mitchell@confurious.io namespaces=thanh namespaces=mitchell ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5";
+    let allowed_signer = AllowedSigner::from_string(allowed_signer);
+    assert!(allowed_signer.is_err());
+}

--- a/tests/allowed-signers.rs
+++ b/tests/allowed-signers.rs
@@ -27,7 +27,7 @@ fn parse_good_allowed_signers() {
     assert!(allowed_signers[1].cert_authority);
     assert_eq!(
         allowed_signers[1].namespaces, 
-        Some(vec!["thanh".to_string(), "mitchell".to_string()])
+        Some(vec!["thanh".to_string(), "#mitchell".to_string()])
     );
     assert!(allowed_signers[1].valid_after.is_none());
     assert_eq!(allowed_signers[1].valid_before, Some(123u64));

--- a/tests/allowed-signers.rs
+++ b/tests/allowed-signers.rs
@@ -1,0 +1,34 @@
+use sshcerts::ssh::AllowedSigners;
+
+#[test]
+fn parse_good_allowed_signers() {
+    let allowed_signers = AllowedSigners::from_path("tests/allowed_signers/good_allowed_signers");
+    assert!(allowed_signers.is_ok());
+    let allowed_signers = allowed_signers.unwrap().allowed_signers;
+    assert_eq!(allowed_signers.len(), 2);
+
+    assert_eq!(
+        allowed_signers[0].key.fingerprint().to_string(),
+        "SHA256:QAtqtvvCePelMMUNPP7madH2zNa1ATxX1nt9L/0C5+M",
+    );
+    assert_eq!(
+        allowed_signers[0].principals,
+        vec!["mitchell@confurious.io".to_string()],
+    );
+    assert!(!allowed_signers[0].cert_authority);
+    assert!(allowed_signers[0].namespaces.is_none());
+    assert!(allowed_signers[0].valid_after.is_none());
+    assert!(allowed_signers[0].valid_before.is_none());
+
+    assert_eq!(
+        allowed_signers[1].principals,
+        vec!["mitchell@confurious.io".to_string(), "mitchel2@confurious.io".to_string()],
+    );
+    assert!(allowed_signers[1].cert_authority);
+    assert_eq!(
+        allowed_signers[1].namespaces, 
+        Some(vec!["thanh".to_string(), "mitchell".to_string()])
+    );
+    assert!(allowed_signers[1].valid_after.is_none());
+    assert_eq!(allowed_signers[1].valid_before, Some(123u64));
+}

--- a/tests/allowed-signers.rs
+++ b/tests/allowed-signers.rs
@@ -47,6 +47,6 @@ fn parse_good_allowed_signers() {
     assert!(allowed_signers[2].valid_after.is_none());
     assert_eq!(
         allowed_signers[2].valid_before,
-        Some(1714881600i64),
+        Some(1714867200i64),
     );
 }

--- a/tests/allowed-signers.rs
+++ b/tests/allowed-signers.rs
@@ -4,7 +4,7 @@ use sshcerts::ssh::AllowedSigners;
 fn parse_good_allowed_signers() {
     let allowed_signers = AllowedSigners::from_path("tests/allowed_signers/good_allowed_signers");
     assert!(allowed_signers.is_ok());
-    let allowed_signers = allowed_signers.unwrap().allowed_signers;
+    let AllowedSigners(allowed_signers) = allowed_signers.unwrap();
     assert_eq!(allowed_signers.len(), 2);
 
     assert_eq!(

--- a/tests/allowed-signers.rs
+++ b/tests/allowed-signers.rs
@@ -44,4 +44,9 @@ fn parse_good_allowed_signers() {
             " andrew   andrew".to_string(),
         ]),
     );
+    assert!(allowed_signers[2].valid_after.is_none());
+    assert_eq!(
+        allowed_signers[2].valid_before,
+        Some(1714881600i64),
+    );
 }

--- a/tests/allowed-signers.rs
+++ b/tests/allowed-signers.rs
@@ -5,7 +5,7 @@ fn parse_good_allowed_signers() {
     let allowed_signers = AllowedSigners::from_path("tests/allowed_signers/good_allowed_signers");
     assert!(allowed_signers.is_ok());
     let AllowedSigners(allowed_signers) = allowed_signers.unwrap();
-    assert_eq!(allowed_signers.len(), 2);
+    assert_eq!(allowed_signers.len(), 3);
 
     assert_eq!(
         allowed_signers[0].key.fingerprint().to_string(),
@@ -31,4 +31,14 @@ fn parse_good_allowed_signers() {
     );
     assert!(allowed_signers[1].valid_after.is_none());
     assert_eq!(allowed_signers[1].valid_before, Some(123u64));
+
+    assert_eq!(
+        allowed_signers[2].namespaces, 
+        Some(vec![
+            "thanh".to_string(),
+            " ".to_string(),
+            "mitchell mitchell".to_string(),
+            " andrew   andrew".to_string(),
+        ]),
+    );
 }

--- a/tests/allowed-signers.rs
+++ b/tests/allowed-signers.rs
@@ -30,7 +30,10 @@ fn parse_good_allowed_signers() {
         Some(vec!["thanh".to_string(), "#mitchell".to_string()])
     );
     assert!(allowed_signers[1].valid_after.is_none());
-    assert_eq!(allowed_signers[1].valid_before, Some(123u64));
+    assert_eq!(
+        allowed_signers[1].valid_before,
+        Some(1714867200i64),
+    );
 
     assert_eq!(
         allowed_signers[2].namespaces, 

--- a/tests/allowed_signers/good_allowed_signers
+++ b/tests/allowed_signers/good_allowed_signers
@@ -3,3 +3,4 @@ mitchell@confurious.io ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf
 # Empty lines are also ignored
 
 mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh,#mitchell" valid-before="123" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5  # End of line comment is ignored
+mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh, ,mitchell mitchell, andrew   andrew" valid-before="123" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5

--- a/tests/allowed_signers/good_allowed_signers
+++ b/tests/allowed_signers/good_allowed_signers
@@ -2,5 +2,5 @@
 mitchell@confurious.io ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5
 # Empty lines are also ignored
 
-mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh,#mitchell" valid-before="20240505" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5  # End of line comment is ignored
+mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh,#mitchell" valid-before="20240505Z" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5  # End of line comment is ignored
 mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh, ,mitchell mitchell, andrew   andrew" valid-before="20240505" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5

--- a/tests/allowed_signers/good_allowed_signers
+++ b/tests/allowed_signers/good_allowed_signers
@@ -1,0 +1,5 @@
+# Comments are ignored
+mitchell@confurious.io ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5
+# Empty lines are also ignored
+
+mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh,mitchell" valid-before="123" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5

--- a/tests/allowed_signers/good_allowed_signers
+++ b/tests/allowed_signers/good_allowed_signers
@@ -2,4 +2,4 @@
 mitchell@confurious.io ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5
 # Empty lines are also ignored
 
-mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh,mitchell" valid-before="123" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5
+mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh,mitchell" valid-before="123" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5  # End of line comment is ignored

--- a/tests/allowed_signers/good_allowed_signers
+++ b/tests/allowed_signers/good_allowed_signers
@@ -2,4 +2,4 @@
 mitchell@confurious.io ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5
 # Empty lines are also ignored
 
-mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh,mitchell" valid-before="123" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5  # End of line comment is ignored
+mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh,#mitchell" valid-before="123" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5  # End of line comment is ignored

--- a/tests/allowed_signers/good_allowed_signers
+++ b/tests/allowed_signers/good_allowed_signers
@@ -2,5 +2,5 @@
 mitchell@confurious.io ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5
 # Empty lines are also ignored
 
-mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh,#mitchell" valid-before="123" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5  # End of line comment is ignored
-mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh, ,mitchell mitchell, andrew   andrew" valid-before="123" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5
+mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh,#mitchell" valid-before="20240505" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5  # End of line comment is ignored
+mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh, ,mitchell mitchell, andrew   andrew" valid-before="20240505" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5

--- a/tests/allowed_signers/good_allowed_signers
+++ b/tests/allowed_signers/good_allowed_signers
@@ -3,4 +3,4 @@ mitchell@confurious.io ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf
 # Empty lines are also ignored
 
 mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh,#mitchell" valid-before="20240505Z" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5  # End of line comment is ignored
-mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh, ,mitchell mitchell, andrew   andrew" valid-before="20240505" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5
+mitchell@confurious.io,mitchel2@confurious.io cert-authority namespaces="thanh, ,mitchell mitchell, andrew   andrew" valid-before="20240505Z" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDO0VQD9TIdICZLWFWwtf7s8/aENve8twGTEmNV0myh5


### PR DESCRIPTION
This adds a new API to parse AllowedSigner. The specification can be found here: https://man.openbsd.org/ssh-keygen.1#ALLOWED_SIGNERS

The parser rejects unsupported options instead of building a HashMap to store additional options.