### PR TITLE
Gebo Updatabo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["ssh", "yubikey", "certs", "certificates"]
 categories = ["authentication"]
 
 [features]
-default = ["all"]
+default = ["all-gebo"]
 
 all = [
     "encrypted-keys",
@@ -19,6 +19,14 @@ all = [
     "x509-support",
     "yubikey-support",
     "fido-support-mozilla",
+]
+
+all-gebo = [
+    "encrypted-keys",
+    "rsa-signing",
+    "x509-support",
+    "yubikey-support",
+    "fido-support",
 ]
 
 all-but-fido = [
@@ -86,8 +94,8 @@ authenticator = { version = "0.4.0-alpha.24", default-features = false, features
 
 
 # Dependencies for fido-support
-ctap-hid-fido2 = { version = "3", optional = true }
-#ctap-hid-fido2 = {git = "https://github.com/gebogebogebo/ctap-hid-fido2", branch="master", optional = true}
+#ctap-hid-fido2 = { version = "3", optional = true }
+ctap-hid-fido2 = { git = "https://github.com/gebogebogebo/ctap-hid-fido2", branch = "develop", optional = true }
 #ctap-hid-fido2 = {git = "https://github.com/obelisk/ctap-hid-fido2", branch="device_by_path", optional = true}
 #ctap-hid-fido2 = {path = "../ctap-hid-fido2", optional = true}
 
@@ -124,7 +132,7 @@ required-features = ["x509-support"]
 
 [[example]]
 name = "new-fido-sshkey"
-required-features = ["fido-support-mozilla"]
+required-features = ["fido-support"]
 
 [[test]]
 name = "privkey-encrypted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ authenticator = { version = "0.4.0-alpha.24", default-features = false, features
 
 # Dependencies for fido-support
 #ctap-hid-fido2 = { version = "3", optional = true }
-ctap-hid-fido2 = { git = "https://github.com/gebogebogebo/ctap-hid-fido2", branch = "develop", optional = true }
+ctap-hid-fido2 = { git = "https://github.com/gebogebogebo/ctap-hid-fido2", branch = "master", optional = true }
 #ctap-hid-fido2 = {git = "https://github.com/obelisk/ctap-hid-fido2", branch="device_by_path", optional = true}
 #ctap-hid-fido2 = {path = "../ctap-hid-fido2", optional = true}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sshcerts"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Mitchell Grenier <mitchell@confurious.io>"]
 edition = "2021"
 license-file = "LICENSE"
@@ -11,22 +11,22 @@ keywords = ["ssh", "yubikey", "certs", "certificates"]
 categories = ["authentication"]
 
 [features]
-default = ["all-gebo"]
+default = ["all"]
 
 all = [
     "encrypted-keys",
     "rsa-signing",
     "x509-support",
     "yubikey-support",
-    "fido-support-mozilla",
+    "fido-support",
 ]
 
-all-gebo = [
+all-mozilla = [
     "encrypted-keys",
     "rsa-signing",
     "x509-support",
     "yubikey-support",
-    "fido-support",
+    "fido-support-mozilla",
 ]
 
 all-but-fido = [

--- a/benches/certs_per_second.rs
+++ b/benches/certs_per_second.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-
-use sshcerts::yubikey::{RetiredSlotId, SlotId, Yubikey};
+use sshcerts::yubikey::piv::Yubikey;
+use yubikey::piv::{RetiredSlotId, SlotId};
 
 fn generate_certs(n: u64) -> () {
     let data = [0; 32];

--- a/src/fido/generate/ctap2_hid.rs
+++ b/src/fido/generate/ctap2_hid.rs
@@ -49,16 +49,16 @@ pub fn generate_new_ssh_key(
         .map_err(|e| Error::FidoError(FidoError::Unknown(e.to_string())))?;
 
     let mut ret = 0x0;
-    if att.flags_user_present_result {
+    if att.flags.user_present_result {
         ret = ret | 0x01;
     }
-    if att.flags_user_verified_result {
+    if att.flags.user_verified_result {
         ret = ret | 0x04;
     }
-    if att.flags_attested_credential_data_included {
+    if att.flags.attested_credential_data_included {
         ret = ret | 0x40;
     }
-    if att.flags_extension_data_included {
+    if att.flags.extension_data_included {
         ret = ret | 0x80;
     }
 


### PR DESCRIPTION
Verifying that we still have consistency with both FIDO2 backends. We still need `tap to select` to make them equally usable though. If we can implement that downstream in `ctap-hid-fido2` then I think we should be good to fully swap between [@mozilla/authenticator-rs](https://github.com/mozilla/authenticator-rs) and [@gebogebo](https://github.com/gebogebogebo/ctap-hid-fido2)