### PR TITLE
Add method to parse private key from Reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sshcerts"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Mitchell Grenier <mitchell@confurious.io>"]
 edition = "2021"
 license-file = "LICENSE"

--- a/src/ssh/privkey.rs
+++ b/src/ssh/privkey.rs
@@ -533,6 +533,11 @@ impl PrivateKey {
         PrivateKey::read_private_key(&mut reader)
     }
 
+    /// Create a private key from an existing reader of decrypted private bytes
+    pub fn from_reader_raw(reader: &mut Reader<'_>) -> Result<PrivateKey> {
+        PrivateKey::read_private_key(reader)
+    }
+
     /// This function is used for extracting a private key from an existing reader.
     pub(crate) fn from_reader(
         reader: &mut Reader<'_>,

--- a/src/ssh/privkey.rs
+++ b/src/ssh/privkey.rs
@@ -291,7 +291,8 @@ impl super::SSHCertificateSigner for PrivateKey {
     }
 }
 impl PrivateKey {
-    fn read_private_key(reader: &mut Reader<'_>) -> Result<Self> {
+    /// Create a private key from an existing reader of decrypted private bytes
+    pub fn read_private_key(reader: &mut Reader<'_>) -> Result<Self> {
         let key_type = reader.read_string()?;
         let kt = KeyType::from_name(&key_type)?;
 
@@ -531,11 +532,6 @@ impl PrivateKey {
     pub fn from_bytes<T: ?Sized + AsRef<[u8]>>(buffer: &T) -> Result<PrivateKey> {
         let mut reader = Reader::new(buffer);
         PrivateKey::read_private_key(&mut reader)
-    }
-
-    /// Create a private key from an existing reader of decrypted private bytes
-    pub fn from_reader_raw(reader: &mut Reader<'_>) -> Result<PrivateKey> {
-        PrivateKey::read_private_key(reader)
     }
 
     /// This function is used for extracting a private key from an existing reader.


### PR DESCRIPTION
Add `from_reader_raw` to allow the caller the ability to continue parsing bytes after the private key bytes, which might include things like constraints.