### PR TITLE
Implement `Clone` for `SshSignature`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sshcerts"
-version = "0.14.1"
+version = "0.14.2"
 authors = ["Mitchell Grenier <mitchell@confurious.io>"]
 edition = "2021"
 license-file = "LICENSE"

--- a/src/ssh/signature.rs
+++ b/src/ssh/signature.rs
@@ -12,7 +12,7 @@ use crate::{error::Error, ssh::Writer, PrivateKey, PublicKey, Result};
 use super::{KeyType, PublicKeyKind, Reader, SSHCertificateSigner};
 
 /// The hash algorithm used to sign the data in the SshSignature
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum HashAlgorithm {
     /// SHA256
     Sha256,
@@ -32,7 +32,7 @@ impl HashAlgorithm {
 
 /// An SSH signature object from signing arbitrary data. This object
 /// has not been verified against a message so it is untrusted.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SshSignature {
     /// The public key used to sign the data
     pub pubkey: PublicKey,


### PR DESCRIPTION
This pull request introduces a minor version bump and adds `Clone` derivations to `SshSignature` and `HashAlgorithm` to improve ergonomics when working with signatures and hash algorithms.