### PR TITLE
PIV unlock should fetch management key alg instead of using firmware default

### DIFF
--- a/src/yubikey/piv/management.rs
+++ b/src/yubikey/piv/management.rs
@@ -3,7 +3,9 @@ use crate::{PublicKey, TouchRequirement};
 use ring::digest;
 
 use yubikey::certificate::Certificate;
-use yubikey::piv::{attest, sign_data as yk_sign_data, AlgorithmId, SlotId};
+use yubikey::piv::{
+    attest, sign_data as yk_sign_data, AlgorithmId, ManagementSlotId, SlotAlgorithmId, SlotId,
+};
 use yubikey::{MgmAlgorithmId, MgmKey, Serial, YubiKey};
 use yubikey::{PinPolicy, TouchPolicy};
 
@@ -209,9 +211,26 @@ impl super::Yubikey {
         Ok(())
     }
 
-    fn management_key_from_bytes(&self, mgm_key: &[u8]) -> Result<MgmKey> {
-        let alg = MgmKey::get_default(&self.yk)?.algorithm_id();
+    fn management_key_from_bytes(&mut self, mgm_key: &[u8]) -> Result<MgmKey> {
+        // Authenticate with the algorithm the management key is actually
+        // configured with, read from the card. Fall back to the firmware
+        // default for devices that don't expose management-key metadata (those
+        // only support 3DES, which the default already resolves to).
+        let alg = match self.management_key_algorithm() {
+            Some(alg) => alg,
+            None => MgmKey::get_default(&self.yk)?.algorithm_id(),
+        };
         MgmKey::from_bytes(mgm_key, Some(alg)).map_err(|_| Error::InvalidManagementKey)
+    }
+
+    /// The algorithm the management key is currently set to, if the device
+    /// exposes it via metadata.
+    fn management_key_algorithm(&mut self) -> Option<MgmAlgorithmId> {
+        let slot = SlotId::Management(ManagementSlotId::Management);
+        match yubikey::piv::metadata(&mut self.yk, slot).map(|m| m.algorithm) {
+            Ok(SlotAlgorithmId::Management(alg)) => Some(alg),
+            _ => None,
+        }
     }
 
     /// Fetch the serial number of the Yubikey

--- a/src/yubikey/piv/management.rs
+++ b/src/yubikey/piv/management.rs
@@ -212,10 +212,8 @@ impl super::Yubikey {
     }
 
     fn management_key_from_bytes(&mut self, mgm_key: &[u8]) -> Result<MgmKey> {
-        // Authenticate with the algorithm the management key is actually
-        // configured with, read from the card. Fall back to the firmware
-        // default for devices that don't expose management-key metadata (those
-        // only support 3DES, which the default already resolves to).
+        // Use the configured algorithm when metadata is available. Older
+        // devices fall back to their default algorithm.
         let alg = match self.management_key_algorithm()? {
             Some(alg) => alg,
             None => MgmKey::get_default(&self.yk)?.algorithm_id(),

--- a/src/yubikey/piv/management.rs
+++ b/src/yubikey/piv/management.rs
@@ -216,7 +216,7 @@ impl super::Yubikey {
         // configured with, read from the card. Fall back to the firmware
         // default for devices that don't expose management-key metadata (those
         // only support 3DES, which the default already resolves to).
-        let alg = match self.management_key_algorithm() {
+        let alg = match self.management_key_algorithm()? {
             Some(alg) => alg,
             None => MgmKey::get_default(&self.yk)?.algorithm_id(),
         };
@@ -225,11 +225,13 @@ impl super::Yubikey {
 
     /// The algorithm the management key is currently set to, if the device
     /// exposes it via metadata.
-    fn management_key_algorithm(&mut self) -> Option<MgmAlgorithmId> {
+    fn management_key_algorithm(&mut self) -> Result<Option<MgmAlgorithmId>> {
         let slot = SlotId::Management(ManagementSlotId::Management);
         match yubikey::piv::metadata(&mut self.yk, slot).map(|m| m.algorithm) {
-            Ok(SlotAlgorithmId::Management(alg)) => Some(alg),
-            _ => None,
+            Ok(SlotAlgorithmId::Management(alg)) => Ok(Some(alg)),
+            Ok(_) => Ok(None),
+            Err(yubikey::Error::NotSupported) => Ok(None),
+            Err(e) => Err(e.into()),
         }
     }
 


### PR DESCRIPTION
Currently, PIV assumes the management key algorithm is the default based on the firmware version. This PR dynamically fetches the algorithm from the Yubikey.

Tested with:
- Yubikey with TDES as default
- Yubikey with AES192 as default
- Yubikey with TDES as non-default

Reviewed by Opus 5 and Copilot.